### PR TITLE
Add beep-based text-to-speech project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+*.wav
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # VoiceOver2
-VoiceOver2
+
+VoiceOver2 is a minimal demonstration project that turns text into a series of
+sine-wave beeps and saves the result as a WAV file. It is intentionally simple
+and runs entirely offline, using only Python's standard library.
+
+## Features
+
+* Offline generation of WAV files from text
+* Command-line interface via `python -m voiceover2` or the `voiceover2` script
+
+## Usage
+
+```bash
+python -m voiceover2 "Hello world" -o hello.wav
+```
+
+The above command creates `hello.wav` containing short beeps representing each
+alphabetical character in the input text.
+
+## Development
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "voiceover2"
+version = "0.1.0"
+description = "Simple offline text-to-speech using beeps"
+authors = [{name = "VoiceOver Dev", email = "dev@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+voiceover2 = "voiceover2.__main__:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_beep.py
+++ b/tests/test_beep.py
@@ -1,0 +1,20 @@
+import sys
+import wave
+from pathlib import Path
+
+# Ensure package root is importable even when PYTHONSAFEPATH is enabled
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from voiceover2 import text_to_beep
+
+
+def test_text_to_beep(tmp_path: Path) -> None:
+    output = tmp_path / "voice.wav"
+    text_to_beep("abc", output)
+    assert output.exists()
+    with wave.open(str(output), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getframerate() == 44_100
+        frames = wav.getnframes()
+        # Expect 3 characters * 0.1s * 44100 frames ~= 13230
+        assert 13_000 < frames < 14_000

--- a/voiceover2/__init__.py
+++ b/voiceover2/__init__.py
@@ -1,0 +1,8 @@
+"""VoiceOver2 package.
+
+Provides simple text-to-speech using generated beeps.
+"""
+
+from .beep import text_to_beep
+
+__all__ = ["text_to_beep"]

--- a/voiceover2/__main__.py
+++ b/voiceover2/__main__.py
@@ -1,0 +1,22 @@
+"""Command line interface for VoiceOver2."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .beep import text_to_beep
+
+
+def main(argv: list[str] | None = None) -> Path:
+    parser = argparse.ArgumentParser(description="Generate a beep-based voiceover")
+    parser.add_argument("text", help="Text to speak")
+    parser.add_argument("-o", "--output", default="output.wav", help="Output WAV file")
+    parser.add_argument("-f", "--frequency", type=float, default=1000.0, help="Frequency of beeps in Hz")
+    parser.add_argument("-d", "--duration", type=float, default=0.1, help="Duration of each character in seconds")
+    args = parser.parse_args(argv)
+    return text_to_beep(args.text, args.output, frequency=args.frequency, char_duration=args.duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/voiceover2/beep.py
+++ b/voiceover2/beep.py
@@ -1,0 +1,71 @@
+"""Basic text-to-speech by converting characters to sine wave beeps.
+
+This module provides a very small offline text-to-speech implementation that
+converts each alphabetical character into a short sine-wave tone. It avoids any
+external dependencies and produces a valid WAV file.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import wave
+from pathlib import Path
+from typing import Iterable
+
+SAMPLE_RATE = 44_100
+AMP = 16_000  # amplitude for the sine wave
+DEFAULT_FREQ = 1_000  # Hz
+CHAR_DURATION = 0.1  # seconds
+
+
+def _sine_wave(frequency: float, frames: int) -> Iterable[bytes]:
+    """Generate frames for a sine wave of ``frequency`` and ``frames`` length."""
+    for i in range(frames):
+        value = int(AMP * math.sin(2 * math.pi * frequency * (i / SAMPLE_RATE)))
+        yield struct.pack("<h", value)
+
+
+def _silence(frames: int) -> Iterable[bytes]:
+    """Generate silent frames."""
+    silence = struct.pack("<h", 0)
+    for _ in range(frames):
+        yield silence
+
+
+def text_to_beep(text: str, output: str | Path, *,
+                 frequency: float = DEFAULT_FREQ,
+                 char_duration: float = CHAR_DURATION) -> Path:
+    """Convert ``text`` to a WAV file of beeps.
+
+    Parameters
+    ----------
+    text:
+        The text to speak. Each alphabetical character produces a short beep;
+        other characters produce silence of equal length.
+    output:
+        Path to the output WAV file.
+    frequency:
+        Frequency of the beep in Hertz. Default is 1000 Hz.
+    char_duration:
+        Duration of each character in seconds. Default is 0.1s.
+
+    Returns
+    -------
+    Path
+        Path to the generated WAV file.
+    """
+    output_path = Path(output)
+    frames_per_char = int(char_duration * SAMPLE_RATE)
+    with wave.open(str(output_path), "w") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)  # 16-bit
+        wav.setframerate(SAMPLE_RATE)
+        for char in text:
+            if char.isalpha():
+                frames = _sine_wave(frequency, frames_per_char)
+            else:
+                frames = _silence(frames_per_char)
+            for frame in frames:
+                wav.writeframes(frame)
+    return output_path


### PR DESCRIPTION
## Summary
- implement basic offline text-to-speech that converts text to sine-wave beeps
- expose command line interface and project packaging
- add tests for WAV generation and frame counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689260b2ec308322ab4c4d9739cb951b